### PR TITLE
Make container image path a dynamic value

### DIFF
--- a/roles/smartgateway/defaults/main.yml
+++ b/roles/smartgateway/defaults/main.yml
@@ -1,3 +1,4 @@
 ---
 # defaults file for smartgateway
 size: 1
+container_image_path: quay.io/redhat-service-assurance/smart-gateway:latest

--- a/roles/smartgateway/tasks/main.yml
+++ b/roles/smartgateway/tasks/main.yml
@@ -28,7 +28,7 @@
               nonroot: true
             containers:
             - name: metrics-smart-gateway
-              image: docker.io/nfvpe/smart_gateway:latest
+              image: '{{ container_image_path }}'
               volumeMounts:
               - name: metrics-config
                 mountPath: /config


### PR DESCRIPTION
The container image path was originally hardcoded in. We want that to be
something configurable from the SmartGateway object when it is created
in OpenShift. This change sets a default container image path that points
at the new quay.io location for the Smart Gateway and makes it something
that can be overridden.

Closes #1