### PR TITLE
Provide events consumer smart gateway deployment

### DIFF
--- a/deploy/crds/smartgateway_v1alpha1_smartgateway_crd.yaml
+++ b/deploy/crds/smartgateway_v1alpha1_smartgateway_crd.yaml
@@ -37,13 +37,18 @@ spec:
             size:
               description: Size sets the number of replicas to create. Defaults to 1.
               type: integer
-            AMQPMetricUrl:
-              description: AMQP1.0 metrics listener example 127.0.0.1:5672/collectd/telemetry. Defaults to using
-                messaging-internal-<name>.<namespace>.src:5672/collectd/telemetry.
+            AMQPUrl:
+              description: AMQP1.x listener example 127.0.0.1:5672/collectd/telemetry. Defaults to using
+                'messaging-internal-<name>.<namespace>.src:5672/collectd/telemetry'.
               type: string
+            elasticUrl:
+              description: URL for ElasticSearch endpoing to connect when the Smart Gateway is operating as an 'events' service type.
+                Defaults to 'elasticsearch.<namespace>.svc:9200'.
+              type: string
+            resetIndex:
+              description: Reset the ElasticSearch index on load. Defaults to 'false'.
             serviceType:
-              description: The service type for this smart gateway. One of 'metrics' or 'events'. Defaults to
-                'metrics'
+              description: The service type for this smart gateway. One of 'metrics' or 'events'. Defaults to 'metrics'.
               type: string
             exporterHost:
               description: Metrics URL for Prometheus to export. Defaults to "0.0.0.0".
@@ -69,3 +74,8 @@ spec:
                 To avoid the round trip for every message, the use of prefetch can be used to allow the receiver to request messages be sent
                 in anticipation of them being sent to us.
               type: integer
+            containerImagePath:
+              description: Path to the container image this Operator will deploy. Value is defined as the standard registry/image_name:tag
+                format. Defaults to 'quay.io/redhat-service-assurance/smart-gateway:latest'
+              type: string
+

--- a/deploy/crds/smartgateway_v1alpha1_smartgateway_events_cr.yaml
+++ b/deploy/crds/smartgateway_v1alpha1_smartgateway_events_cr.yaml
@@ -1,10 +1,12 @@
 apiVersion: smartgateway.infra.watch/v1alpha1
 kind: SmartGateway
 metadata:
-  name: metrics
+  name: events
 spec:
   size: 1
   amqp_url: qdr-white.sa-telemetry.svc.cluster.local:5672/collectd/telemetry
+  elastic_url: https://elasticsearch.sa-telemetry.svc:9200
   debug: "false"
+  service_type: "events"
   container_image_path: quay.io/redhat-service-assurance/smart-gateway:latest
 # vim: set tabstop=2 shiftwidth=2 expandtab smartindent:

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -6,16 +6,16 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      name: smart-gateway-operator
+      app: smart-gateway-operator
   template:
     metadata:
       labels:
-        name: smart-gateway-operator
+        app: smart-gateway-operator
     spec:
       serviceAccountName: smart-gateway-operator
       containers:
         - name: smart-gateway-operator
-          image: "quay.io/redhat-service-assurance/smart-gateway-operator:latest"
+          image: quay.io/redhat-service-assurance/smart-gateway-operator:latest
           imagePullPolicy: "Always"
           env:
             - name: WATCH_NAMESPACE

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -46,6 +46,7 @@ rules:
   - create
   - list
   - patch
+  - watch
 - apiGroups:
   - apps
   resourceNames:
@@ -55,7 +56,6 @@ rules:
   - deploymentconfigs/finalizers
   verbs:
   - update
-  - watch
 - apiGroups:
   - smartgateway.infra.watch
   resources:

--- a/roles/smartgateway/defaults/main.yml
+++ b/roles/smartgateway/defaults/main.yml
@@ -2,3 +2,4 @@
 # defaults file for smartgateway
 size: 1
 container_image_path: quay.io/redhat-service-assurance/smart-gateway:latest
+service_type: metrics

--- a/roles/smartgateway/handlers/main.yml
+++ b/roles/smartgateway/handlers/main.yml
@@ -1,2 +1,0 @@
----
-# handlers file for smartgateway

--- a/roles/smartgateway/tasks/deployment.yml
+++ b/roles/smartgateway/tasks/deployment.yml
@@ -1,0 +1,42 @@
+---
+# tasks file for smartgateway
+- name: Start the smart gateway
+  k8s:
+    resource_definition:
+      apiVersion: apps.openshift.io/v1
+      kind: DeploymentConfig
+      metadata:
+        name: '{{ meta.name }}-smartgateway'
+        namespace: '{{ meta.namespace }}'
+      spec:
+        replicas: '{{ size }}'
+        template:
+          metadata:
+            labels:
+              app: smart-gateway
+          spec:
+            securityContext:
+              nonroot: true
+            containers:
+            - name: smart-gateway
+              image: '{{ container_image_path }}'
+              volumeMounts:
+              - name: sg-config
+                mountPath: /config
+              args:
+                - '-config=/config/smartgateway_config.json'
+                - '-uname=$(MY_POD_NAME)'
+                - '-servicetype={{ service_type }}'
+              env:
+                - name: MY_POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      apiVersion: v1
+                      fieldPath: metadata.name
+              ports:
+              - name: "{{ service_type }}"
+                containerPort: 8081
+            volumes:
+            - name: sg-config
+              configMap:
+                name: "{{ meta.name }}-smartgateway"

--- a/roles/smartgateway/tasks/main.yml
+++ b/roles/smartgateway/tasks/main.yml
@@ -1,104 +1,20 @@
 ---
-# tasks file for smartgateway
 - name: Write out configmap for smart gateway
   template:
     dest: /tmp/configmap.yaml
-    src: configmap.yaml.j2
+    src: "{{ service_type }}-configmap.yaml.j2"
 
 - name: Smart gateway ConfigMap
   k8s:
     src: /tmp/configmap.yaml
 
-- name: Start the smart gateway
-  k8s:
-    resource_definition:
-      apiVersion: apps.openshift.io/v1
-      kind: DeploymentConfig
-      metadata:
-        name: '{{ meta.name }}-smartgateway'
-        namespace: '{{ meta.namespace }}'
-      spec:
-        replicas: '{{ size }}'
-        template:
-          metadata:
-            labels:
-              app: smart-gateway
-          spec:
-            securityContext:
-              nonroot: true
-            containers:
-            - name: metrics-smart-gateway
-              image: '{{ container_image_path }}'
-              volumeMounts:
-              - name: metrics-config
-                mountPath: /config
-              args:
-                - '-config=/config/sa.metrics.config.json'
-                - '-uname=$(MY_POD_NAME)'
-                - '-servicetype=metrics'
-              env:
-                - name: MY_POD_NAME
-                  valueFrom:
-                    fieldRef:
-                      apiVersion: v1
-                      fieldPath: metadata.name
-              ports:
-              - name: metrics
-                containerPort: 8081
-            volumes:
-            - name: metrics-config
-              configMap:
-                name: "{{ meta.name }}-smartgateway"
+- name: Create deployment for the Smart Gateway
+  include_tasks: deployment.yml
 
-- name: Service for the smart gateway
-  k8s:
-    resource_definition:
-      apiVersion: v1
-      kind: Service
-      metadata:
-        name: '{{ meta.name }}-smartgateway'
-        namespace: '{{ meta.namespace }}'
-        labels:
-          app: smart-gateway
-      spec:
-        ports:
-        - name: metrics
-          port: 8081
-          targetPort: 8081
-          protocol: TCP
-        selector:
-          app: smart-gateway
+- name: Create service for the Smart Gateway
+  include_tasks: service.yml
+  when: service_type == "metrics"
 
-- name: Service monitor for smart gateway
-  k8s:
-    resource_definition:
-      apiVersion: monitoring.coreos.com/v1
-      kind: ServiceMonitor
-      metadata:
-        name: '{{ meta.name }}-smartgateway'
-        namespace: '{{ meta.namespace }}'
-        labels:
-          app: smart-gateway
-      spec:
-        selector:
-          matchLabels:
-            app: smart-gateway
-        namespaceSelector:
-          matchNames:
-          - '{{ meta.namespace }}'
-        endpoints:
-        - port: metrics
-          interval: 1s
-          metricRelabelings:
-          - action: labeldrop
-            regex: pod
-            sourcelabels: []
-          - action: labeldrop
-            regex: namespace
-            sourcelabels: []
-          - action: labeldrop
-            regex: instance
-            sourcelabels: []
-          - action: labeldrop
-            regex: job
-            sourcelabels: []
+- name: Create ServiceMonitor for Smart Gateway
+  include_tasks: servicemonitor.yml
+  when: service_type == "metrics"

--- a/roles/smartgateway/tasks/service.yml
+++ b/roles/smartgateway/tasks/service.yml
@@ -1,0 +1,18 @@
+- name: Service for the smart gateway
+  k8s:
+    resource_definition:
+      apiVersion: v1
+      kind: Service
+      metadata:
+        name: '{{ meta.name }}-smartgateway'
+        namespace: '{{ meta.namespace }}'
+        labels:
+          app: smart-gateway
+      spec:
+        ports:
+        - name: prom-http
+          port: 8081
+          targetPort: 8081
+          protocol: TCP
+        selector:
+          app: smart-gateway

--- a/roles/smartgateway/tasks/servicemonitor.yml
+++ b/roles/smartgateway/tasks/servicemonitor.yml
@@ -1,0 +1,33 @@
+- name: Service monitor for smart gateway
+  k8s:
+    resource_definition:
+      apiVersion: monitoring.coreos.com/v1
+      kind: ServiceMonitor
+      metadata:
+        name: '{{ meta.name }}-smartgateway'
+        namespace: '{{ meta.namespace }}'
+        labels:
+          app: smart-gateway
+      spec:
+        selector:
+          matchLabels:
+            app: smart-gateway
+        namespaceSelector:
+          matchNames:
+          - '{{ meta.namespace }}'
+        endpoints:
+        - port: prom-http
+          interval: 1s
+          metricRelabelings:
+          - action: labeldrop
+            regex: pod
+            sourcelabels: []
+          - action: labeldrop
+            regex: namespace
+            sourcelabels: []
+          - action: labeldrop
+            regex: instance
+            sourcelabels: []
+          - action: labeldrop
+            regex: job
+            sourcelabels: []

--- a/roles/smartgateway/templates/events-configmap.yaml.j2
+++ b/roles/smartgateway/templates/events-configmap.yaml.j2
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ meta.name }}-smartgateway
+  namespace: {{ meta.namespace }}
+data:
+  "smartgateway_config.json": |
+    {
+            "AMQP1EventURL": "{{ amqp_url | default('messaging-internal-' + meta.name + '.' + meta.namespace + '.svc:5672/collectd/notify') }}",
+            "ElasticHostURL": "{{ elastic_url | default('elasticsearch.' + meta.namespace + '.svc:9200') }}",
+            "AlertManagerURL": "{{ alertmanager_url | default('alertmanager.' + meta.namespace + '.svc:9093/api/v1/alerts') }}",
+            "ResetIndex": {{ reset_index | default('false') }},
+            "ServiceType": "{{ service_type | default('metrics') }}",
+            "Debug": {{ debug | default('false') }},
+            "Prefetch": {{ prefetch | default('0') }}
+    }

--- a/roles/smartgateway/templates/metrics-configmap.yaml.j2
+++ b/roles/smartgateway/templates/metrics-configmap.yaml.j2
@@ -4,9 +4,9 @@ metadata:
   name: {{ meta.name }}-smartgateway
   namespace: {{ meta.namespace }}
 data:
-  "sa.metrics.config.json": |
+  "smartgateway_config.json": |
     {
-            "AMQP1MetricURL": "{{ amqpmetric_url | default('messaging-internal-{{ meta.name }}.{{ meta.namespace }}.svc:5672/collectd/telemetry') }}",
+            "AMQP1MetricURL": "{{ amqp_url | default('messaging-internal-' + meta.name + '.' + meta.namespace + '.svc:5672/collectd/telemetry') }}",
             "Exporterhost": "{{ exporter_host | default('0.0.0.0') }}",
             "Exporterport": {{ exporter_port | default('8081') }},
             "CPUStats": {{ cpu_stats | default('false') }},

--- a/roles/smartgateway/vars/main.yml
+++ b/roles/smartgateway/vars/main.yml
@@ -1,2 +1,0 @@
----
-# vars file for smartgateway


### PR DESCRIPTION
Provides an events consumer smart gateway configuration. Allows for connection
to an ElasticSearch pod within the sa-telemetry namespace.

Deployment can be validated with the following manifest:

```
apiVersion: smartgateway.infra.watch/v1alpha1
kind: SmartGateway
metadata:
  name: events
spec:
  size: 1
  amqp_url: qdr-white.sa-telemetry.svc.cluster.local:5672/collectd/notify
  debug: "true"
  container_image_path: 172.30.1.1:5000/sa-telemetry/smart-gateway
  service_type: "events"
```