### PR TITLE
Adjusting labels that don't interact with telemetry-framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,34 +1,121 @@
 # smart-gateway-operator
 
-Operator for the smart gateway available
-https://github.com/redhat-service-assurance/smart-gateway
+Operator for the infra.watch [smart gateway](https://github.com/redhat-service-assurance/smart-gateway)
 
-# Building
+## Deployment
 
-You can build this with the `operator-sdk` by running:
+Deploy the components under the `deploy/` directory.
 
-    operator-sdk build quay.io/redhat-service-assurance/smart-gateway-operator:latest
+```shell
+oc login -u system:admin
+oc apply -f deploy/operator.yaml
+oc apply -f deploy/crds/smartgateway_v1alpha1_smartgateway_crd.yaml
+oc apply -f deploy/role_binding.yaml
+oc apply -f deploy/role.yaml
+oc apply -f deploy/service_account.yaml
+```
 
-# Deployment
+## Build and test
 
-You'll need to deploy the components under the `deploy/` directory.
+A procedure for testing in minishift
 
-    oc apply -f deploy/smartgateway_v1alpha1_smartgateway_crd.yaml
-    oc apply -f deploy/operator.yaml
-    oc apply -f deploy/role_binding.yaml
-    oc apply -f deploy/role.yaml
-    oc apply -f deploy/service_account.yaml
+### Set up minishift and docker
 
-# Creating a Smart Gateway
+Enable the edge routing for the minishift registry and log into it:
 
-Start a new smart gateway by creating a CustomResource object. You can do this
-with the `smartgateway_v1alpha1_smartgateway_cr.yaml` file in `deploy/crds/`.
+```shell
+minishift addons enable registry-route # Must be BEFORE you start minishift (https://github.com/minishift/minishift/issues/2060)
+minishift addons enable admin-user
+minishift start
+oc login -u admin -p admin
+oc new-project sg-test
+docker login -u admin -p `oc whoami -t` $(minishift openshift registry)
+```
+
+### Build the operator
+
+Build a "dev" version of the operator image:
+
+```shell
+DOCKER_IMAGE="$(minishift openshift registry)/$(oc project -q)/smart-gateway-operator:dev"
+operator-sdk build "${DOCKER_IMAGE}"
+docker push "${DOCKER_IMAGE}"
+```
+
+### Deploy with the newly built operator
+
+Follow the same process as documented in the "Deployment" section above, but
+apply a patched version of the operator resource that uses the newly built
+operator image:
+
+```shell
+oc patch --dry-run -f deploy/operator.yaml -o yaml -p \
+  '{"spec":{"template":{"spec":{"containers":[{"name": "smart-gateway-operator", "image": "'"$(oc registry info)/$(oc project -q)"'/smart-gateway-operator:dev"}]}}}}' \
+  | oc apply -f -
+... (See above)
+```
+
+### FIXME - Unit testing
+
+With molecule (Currently broken)
+
+### Integration testing
+
+Test the newly built operator with the Service Assurance Framework (SAF).
+
+#### Prepare project
+
+Create the sa-telemetry project and push the operator image to an image stream
+in its registry namespace.
+
+```shell
+oc delete project sa-telemetry
+oc new-project sa-telemetry
+SA_DOCKER_IMAGE="$(minishift openshift registry)/$(oc project -q)/smart-gateway-operator:latest"
+docker tag "${DOCKER_IMAGE}" "${SA_DOCKER_IMAGE}"
+docker push "${SA_DOCKER_IMAGE}"
+oc import-image --insecure=true smart-gateway-operator:latest --from=$(oc registry info)/sa-telemetry/smart-gateway-operator --confirm
+```
+
+**NOTE:** The `--insecure=true` flag is to work around an issue where the
+openshift internal registry is not trusted. It is expected we can drop it
+in a future revision. See [minishift issue](https://github.com/minishift/minishift/issues/2544)
+and [openshift issue](https://github.com/openshift/origin/issues/20604)
+
+#### Deploy SAF
+
+Follow the process for deploying SAF in a testing environment. Hints:
+
+* [Travis automation](https://github.com/redhat-service-assurance/telemetry-framework/blob/master/.travis.yml#L12)
+* [SAF Documentation](https://github.com/redhat-service-assurance/telemetry-framework/blob/master/deploy/README.md#quickstart-minishift)
+
+NOTE: This process will cause a couple of expected errors while running the
+`quickstart.sh` script in telemetry-framework:
+
+* `Error from server (AlreadyExists): project.project.openshift.io "sa-telemetry" already exists`
+  * It was created in order to stage the operator image
+* `error: the tag "latest" points to "172.30.1.1:5000/sa-telemetry/smart-gateway-operator" - use the 'tag' command if you want to change the source to "quay.io/redhat-service-assurance/smart-gateway-operator:latest`
+  * It was created in order to stage the operator image
+* `Error from server (AlreadyExists): error when creating "operators/smartgateway/crds/smartgateway_v1alpha1_smartgateway_crd.yaml": customresourcedefinitions.apiextensions.k8s.io "smartgateways.smartgateway.infra.watch" already exists`
+  * You may see this if you have been testing the operator prior to deploying it
+    for integration with SAF
+
+## Creating a Smart Gateway
+
+Start a new smart gateway by creating a CustomResource object
+based on the example:
+
+```shell
+oc create -f deploy/crds/smartgateway_v1alpha1_smartgateway_cr.yaml
+```
 
 Here is an example CustomResource for the `white` smart gateway.
 
-    apiVersion: smartgateway.infra.watch/v1alpha1
-    kind: SmartGateway
-    metadata:
-      name: white
-    spec:
-      size: 1
+```yaml
+apiVersion: smartgateway.infra.watch/v1alpha1
+kind: SmartGateway
+metadata:
+  name: white
+spec:
+  size: 1
+```

--- a/README.md
+++ b/README.md
@@ -24,11 +24,12 @@ A procedure for testing in minishift
 Enable the edge routing for the minishift registry and log into it:
 
 ```shell
-minishift addons enable registry-route # Must be BEFORE you start minishift (https://github.com/minishift/minishift/issues/2060)
+minishift addons enable registry-route  # Must be BEFORE you start minishift (https://github.com/minishift/minishift/issues/2060)
 minishift addons enable admin-user
 minishift start
 oc login -u admin -p admin
 oc new-project sg-test
+eval $(minishift docker-env)  # Note this reconfigures your DOCKER_HOST
 docker login -u admin -p `oc whoami -t` $(minishift openshift registry)
 ```
 
@@ -44,8 +45,9 @@ docker push "${DOCKER_IMAGE}"
 
 ### Deploy with the newly built operator
 
-Follow the same process as documented in the "Deployment" section above, but
-apply a patched version of the operator resource that uses the newly built
+Follow the same process as documented in the [Deployment](#Deployment) section
+above, but apply a patched version of the operator resource that uses the newly
+built
 operator image:
 
 ```shell
@@ -65,7 +67,7 @@ Test the newly built operator with the Service Assurance Framework (SAF).
 
 #### Prepare project
 
-Create the sa-telemetry project and push the operator image to an image stream
+Create the `sa-telemetry` project and push the operator image to an image stream
 in its registry namespace.
 
 ```shell

--- a/README.md
+++ b/README.md
@@ -65,18 +65,26 @@ With molecule (Currently broken)
 
 Test the newly built operator with the Service Assurance Framework (SAF).
 
+The sections below can be iterated on during development, in brief:
+
+1. Clean out the project space
+1. Build the operator
+1. Import the operator to an ImageStream in the project
+1. Deploy SAF in the same project
+
 #### Prepare project
 
 Create the `sa-telemetry` project and push the operator image to an image stream
 in its registry namespace.
 
 ```shell
-oc delete project sa-telemetry
-oc new-project sa-telemetry
-SA_DOCKER_IMAGE="$(minishift openshift registry)/$(oc project -q)/smart-gateway-operator:latest"
-docker tag "${DOCKER_IMAGE}" "${SA_DOCKER_IMAGE}"
+PROJECT=sa-telemetry
+oc delete project ${PROJECT}
+oc new-project ${PROJECT}
+SA_DOCKER_IMAGE="$(minishift openshift registry)/${PROJECT}/smart-gateway-operator:dev"
+operator-sdk build "${SA_DOCKER_IMAGE}"
 docker push "${SA_DOCKER_IMAGE}"
-oc import-image --insecure=true smart-gateway-operator:latest --from=$(oc registry info)/sa-telemetry/smart-gateway-operator --confirm
+oc import-image --insecure=true smart-gateway-operator:latest --from=$(oc registry info)/${PROJECT}/smart-gateway-operator:dev --confirm
 ```
 
 **NOTE:** The `--insecure=true` flag is to work around an issue where the

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Operator for the infra.watch [smart gateway](https://github.com/redhat-service-assurance/smart-gateway)
 
-## Deployment
+## Deployment to an existing cluster
 
 Deploy the components under the `deploy/` directory.
 
@@ -15,9 +15,21 @@ oc apply -f deploy/role.yaml
 oc apply -f deploy/service_account.yaml
 ```
 
-## Build and test
+## Build and test against minishift
 
 A procedure for testing in minishift
+
+Tested with the following versions:
+* docker
+  * 18.09.7
+* kubernetes 
+  * v1.11.0+d4cacc0
+* minishift 
+  * v1.34.0+f5db7cb
+* oc
+  * v3.11.0+0cbc58b
+* operator-sdk
+  * v0.9.0
 
 ### Set up minishift and docker
 

--- a/README.md
+++ b/README.md
@@ -21,14 +21,17 @@ A procedure for testing in minishift
 
 Tested with the following versions:
 * docker
+  * 18.06.0-ce
   * 18.09.7
-* kubernetes 
+* kubernetes
   * v1.11.0+d4cacc0
-* minishift 
+* minishift
   * v1.34.0+f5db7cb
+  * v1.34.1+c2ff9cb
 * oc
   * v3.11.0+0cbc58b
 * operator-sdk
+  * v0.6.0
   * v0.9.0
 
 ### Set up minishift and docker

--- a/deploy/crds/smartgateway_v1alpha1_smartgateway_crd.yaml
+++ b/deploy/crds/smartgateway_v1alpha1_smartgateway_crd.yaml
@@ -10,6 +10,13 @@ spec:
     plural: smartgateways
     singular: smartgateway
   scope: Namespaced
+  version: v1alpha1
+  subresources:
+    status: {}
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
   validation:
     openAPIV3Schema:
       properties:
@@ -62,8 +69,3 @@ spec:
                 To avoid the round trip for every message, the use of prefetch can be used to allow the receiver to request messages be sent
                 in anticipation of them being sent to us.
               type: integer
-  version: v1alpha1
-  versions:
-  - name: v1alpha1
-    served: true
-    storage: true

--- a/roles/smartgateway/tasks/main.yml
+++ b/roles/smartgateway/tasks/main.yml
@@ -22,7 +22,7 @@
         template:
           metadata:
             labels:
-              app: prometheus-{{ meta.name }}
+              app: smart-gateway
           spec:
             securityContext:
               nonroot: true
@@ -49,9 +49,6 @@
             - name: metrics-config
               configMap:
                 name: "{{ meta.name }}-smartgateway"
-            nodeSelector:
-              node: "{{ meta.name }}"
-              application: sa-telemetry
 
 - name: Service for the smart gateway
   k8s:
@@ -62,7 +59,7 @@
         name: '{{ meta.name }}-smartgateway'
         namespace: '{{ meta.namespace }}'
         labels:
-          smartgateway: '{{ meta.name }}'
+          app: smart-gateway
       spec:
         ports:
         - name: metrics
@@ -70,7 +67,7 @@
           targetPort: 8081
           protocol: TCP
         selector:
-          app: prometheus-{{ meta.name }}
+          app: smart-gateway
 
 - name: Service monitor for smart gateway
   k8s:
@@ -81,11 +78,12 @@
         name: '{{ meta.name }}-smartgateway'
         namespace: '{{ meta.namespace }}'
         labels:
+          app: smart-gateway
           smartgateway: '{{ meta.name }}'
       spec:
         selector:
           matchLabels:
-            smartgateway: '{{ meta.name }}'
+            app: smart-gateway
         namespaceSelector:
           matchNames:
           - '{{ meta.namespace }}'


### PR DESCRIPTION
* Changed CRD to have "subresources.status" like in telemetry-framework repo
  * Fixes "the server could not find the requested resource"
* Removed label based node affinity
* Removed "colored" affinity (blue/green/white)
* Standardized on `app: smart-gateway`
* Removed some other confusing labels
  * ServiceMonitor 'smartgateway: white' label stays for now
  * Will handle in a seperate PR because co-ordinating change required here:
https://github.com/redhat-service-assurance/telemetry-framework/blob/3562d4492a22fdd784c7689fd06cc50835d0a779/deploy/service-assurance/prometheus/prometheus.yaml#L35
* Added some build and test docs
* Fixed markdownlint problems in existing docs
* Minor doc cleanups