### PR TITLE
removing `smartgateway: white` label

### DIFF
--- a/roles/smartgateway/tasks/main.yml
+++ b/roles/smartgateway/tasks/main.yml
@@ -79,7 +79,6 @@
         namespace: '{{ meta.namespace }}'
         labels:
           app: smart-gateway
-          smartgateway: '{{ meta.name }}'
       spec:
         selector:
           matchLabels:


### PR DESCRIPTION
* Requires co-ordinating change in telemetry-framework: https://github.com/redhat-service-assurance/telemetry-framework/pull/43