### PR TITLE
Service[Monitor] fixes for multiple SGs

### DIFF
--- a/roles/smartgateway/tasks/service.yml
+++ b/roles/smartgateway/tasks/service.yml
@@ -16,3 +16,4 @@
           protocol: TCP
         selector:
           app: smart-gateway
+          deploymentconfig: '{{ meta.name }}-smartgateway'

--- a/roles/smartgateway/tasks/servicemonitor.yml
+++ b/roles/smartgateway/tasks/servicemonitor.yml
@@ -4,7 +4,7 @@
       apiVersion: monitoring.coreos.com/v1
       kind: ServiceMonitor
       metadata:
-        name: '{{ meta.name }}-smartgateway'
+        name: 'smartgateway'
         namespace: '{{ meta.namespace }}'
         labels:
           app: smart-gateway


### PR DESCRIPTION
* We create a Service for each SG, but each one targeted EVERY SG
  * Prometheus would scrape each Service and which SG pod responded was random
  * Now the Service targets just the pods with the corresponding name via the
    deploymentconfig label
* We created a ServiceMonitor for each SG, but this is unnecesarry
  * Each ServiceMonitor targets EVERY SG service, so they are redundant
  * Adjusted templating so there is only ever one ServiceMonitor

I deployed this to my quicklab and got the expected behaviour:
 * I created two SmartGateways
 * Got two Services each with one backend
 * Got one ServiceMonitor
 * ServiceMonitor discovered two targets
 * Only the target I sent messages to (via amqp) shows any prometheus data

Before this change I was seeing prometheus data from both SGs, even though one
of them was not actually getting any messages.