### PR TITLE
Provide initial support for Events Smart Gateway

### DIFF
--- a/roles/smartgateway/defaults/main.yml
+++ b/roles/smartgateway/defaults/main.yml
@@ -2,4 +2,3 @@
 # defaults file for smartgateway
 size: 1
 container_image_path: quay.io/redhat-service-assurance/smart-gateway:latest
-service_type: metrics

--- a/roles/smartgateway/tasks/deployment.yml
+++ b/roles/smartgateway/tasks/deployment.yml
@@ -23,6 +23,8 @@
               volumeMounts:
               - name: sg-config
                 mountPath: /config
+              - name: elastic-certs
+                mountPath: /config/certs
               args:
                 - '-config=/config/smartgateway_config.json'
                 - '-uname=$(MY_POD_NAME)'
@@ -40,3 +42,7 @@
             - name: sg-config
               configMap:
                 name: "{{ meta.name }}-smartgateway"
+            - name: elastic-certs
+              secret:
+                secretName: elasticsearch
+

--- a/roles/smartgateway/tasks/main.yml
+++ b/roles/smartgateway/tasks/main.yml
@@ -9,7 +9,13 @@
     src: /tmp/configmap.yaml
 
 - name: Create deployment for the Smart Gateway
-  include_tasks: deployment.yml
+  template:
+    dest: /tmp/deployment.yaml
+    src: deployment.yaml.j2
+
+- name: Deploy the Smart Gateway
+  k8s:
+    src: /tmp/deployment.yaml
 
 - name: Create service for the Smart Gateway
   include_tasks: service.yml

--- a/roles/smartgateway/templates/deployment.yaml.j2
+++ b/roles/smartgateway/templates/deployment.yaml.j2
@@ -1,0 +1,46 @@
+apiVersion: apps.openshift.io/v1
+kind: DeploymentConfig
+metadata:
+  name: '{{ meta.name }}-smartgateway'
+  namespace: '{{ meta.namespace }}'
+spec:
+  replicas: '{{ size }}'
+  template:
+    metadata:
+      labels:
+        app: smart-gateway
+    spec:
+      securityContext:
+        nonroot: true
+      containers:
+      - name: smart-gateway
+        image: '{{ container_image_path }}'
+        volumeMounts:
+        - name: sg-config
+          mountPath: /config
+{% if service_type == 'events' %}
+        - name: elastic-certs
+          mountPath: /config/certs
+{% endif %}
+        args:
+          - '-config=/config/smartgateway_config.json'
+          - '-uname=$(MY_POD_NAME)'
+          - '-servicetype={{ service_type }}'
+        env:
+          - name: MY_POD_NAME
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: metadata.name
+        ports:
+        - name: "{{ service_type }}"
+          containerPort: 8081
+      volumes:
+      - name: sg-config
+        configMap:
+          name: "{{ meta.name }}-smartgateway"
+{% if service_type == 'events' %}
+      - name: elastic-certs
+        secret:
+          secretName: elasticsearch
+{% endif %}

--- a/roles/smartgateway/templates/events-configmap.yaml.j2
+++ b/roles/smartgateway/templates/events-configmap.yaml.j2
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -8,9 +9,20 @@ data:
     {
             "AMQP1EventURL": "{{ amqp_url | default('messaging-internal-' + meta.name + '.' + meta.namespace + '.svc:5672/collectd/notify') }}",
             "ElasticHostURL": "{{ elastic_url | default('elasticsearch.' + meta.namespace + '.svc:9200') }}",
-            "AlertManagerURL": "{{ alertmanager_url | default('alertmanager.' + meta.namespace + '.svc:9093/api/v1/alerts') }}",
             "ResetIndex": {{ reset_index | default('false') }},
-            "ServiceType": "{{ service_type | default('metrics') }}",
+            "ServiceType": "{{ service_type | default('events') }}",
             "Debug": {{ debug | default('false') }},
-            "Prefetch": {{ prefetch | default('0') }}
+            "Prefetch": {{ prefetch | default('0') }},
+            "UniqueName": "{{ unique_name | default(meta.name + '-smartgateway') }}",
+            "AlertManagerEnabled": {{ alert_manager_enabled | default('false') }},
+            "AlertManagerURL": "{{ alert_manager_url | default('') }}",
+            "APIEnabled": {{ api_enabled | default('false') }},
+            "APIEndpointURL": "{{ api_endpoint_url | default('') }}",
+            "PublishEventEnabled": {{ publish_event_enabled | default('false') }},
+            "AMQP1PublishURL": "{{ amqp_publish_url | default('') }}",
+            "TlsClientCert": "{{ tls_client_cert | default('') }}",
+            "TlsClientKey": "{{ tls_client_key | default('') }}",
+            "TlsCaCert": "{{ tls_ca_cert | default('') }}",
+            "TlsServerName": "{{ tls_server_name | default('') }}",
+            "UseTls": {{ use_tls | default('false') }}
     }


### PR DESCRIPTION
This change provides the initial support for creating an Smart Gateway
for ServiceType of 'events'.

Depends on: https://github.com/redhat-service-assurance/smart-gateway/pull/34