### PR TITLE
Remove configuration option UseSample

### DIFF
--- a/deploy/crds/smartgateway_v1alpha1_smartgateway_crd.yaml
+++ b/deploy/crds/smartgateway_v1alpha1_smartgateway_crd.yaml
@@ -62,9 +62,6 @@ spec:
             dataCount:
               description: Stop after receiving this many messages in total (-1 forever). Defaults to '-1'.
               type: string
-            useSample:
-              description: Use sample data instead of AMQP .This will not fetch any data from AMQP. Defaults to 'false'.
-              type: string
             debug:
               description: Enable verbose debugging statements. Defaults to 'false'.
               type: string

--- a/deploy/olm-catalog/smartgateway-operator/0.1.0/smartgateway-operator.crd.yaml
+++ b/deploy/olm-catalog/smartgateway-operator/0.1.0/smartgateway-operator.crd.yaml
@@ -62,9 +62,6 @@ spec:
             dataCount:
               description: Stop after receiving this many messages in total (-1 forever). Defaults to '-1'.
               type: string
-            useSample:
-              description: Use sample data instead of AMQP .This will not fetch any data from AMQP. Defaults to 'false'.
-              type: string
             debug:
               description: Enable verbose debugging statements. Defaults to 'false'.
               type: string

--- a/roles/smartgateway/templates/metrics-configmap.yaml.j2
+++ b/roles/smartgateway/templates/metrics-configmap.yaml.j2
@@ -11,7 +11,6 @@ data:
             "Exporterport": {{ exporter_port | default('8081') }},
             "CPUStats": {{ cpu_stats | default('false') }},
             "DataCount": {{ data_count | default('-1') }},
-            "UseSample": {{ use_sample | default('false') }},
             "ServiceType": "{{ service_type | default('metrics') }}",
             "Debug": {{ debug | default('true') }},
             "Prefetch": {{ prefetch | default('1000') }}


### PR DESCRIPTION
With the latest Smart Gateway refactoring and changes, the implementation
of UseSample has been dropped. There wasn't enough implementation left that
any of this worked, but with the drop of the struct contents for UseSample
having it as an option in the Operator is no longer valid.