### PR TITLE
Allow Prometheus scrape interval to be configurable

### DIFF
--- a/roles/smartgateway/README.md
+++ b/roles/smartgateway/README.md
@@ -1,38 +1,11 @@
-Role Name
+smart-gateway-operator
 =========
 
-A brief description of the role goes here.
-
-Requirements
-------------
-
-Any pre-requisites that may not be covered by Ansible itself or the role should be mentioned here. For instance, if the role uses the EC2 module, it may be a good idea to mention in this section that the boto package is required.
-
-Role Variables
---------------
-
-A description of the settable variables for this role should go here, including any variables that are in defaults/main.yml, vars/main.yml, and any variables that can/should be set via parameters to the role. Any variables that are read from other roles and/or the global scope (ie. hostvars, group vars, etc.) should be mentioned here as well.
-
-Dependencies
-------------
-
-A list of other roles hosted on Galaxy should go here, plus any details in regards to parameters that may need to be set for other roles, or variables that are used from other roles.
-
-Example Playbook
-----------------
-
-Including an example of how to use your role (for instance, with variables passed in as parameters) is always nice for users too:
-
-    - hosts: servers
-      roles:
-         - { role: username.rolename, x: 42 }
+Provides the Smart Gateway Operator that can be used in an OpenShift
+environment to deploy Smart Gateways. The Smart Gateway is a component of the
+Service Assurance Framework.
 
 License
 -------
 
-BSD
-
-Author Information
-------------------
-
-An optional section for the role authors to include contact information, or a website (HTML is not allowed).
+Apache

--- a/roles/smartgateway/defaults/main.yml
+++ b/roles/smartgateway/defaults/main.yml
@@ -2,3 +2,4 @@
 # defaults file for smartgateway
 size: 1
 container_image_path: quay.io/redhat-service-assurance/smart-gateway:latest
+prometheus_scrape_interval: 1s

--- a/roles/smartgateway/meta/main.yml
+++ b/roles/smartgateway/meta/main.yml
@@ -1,60 +1,14 @@
 galaxy_info:
-  author: your name
-  description: your description
-  company: your company (optional)
+  author: Red Hat CloudOps
+  description: Smart Gateway Operator
+  company: Red Hat, Inc.
 
-  # If the issue tracker for your role is not on github, uncomment the
-  # next line and provide a value
-  # issue_tracker_url: http://example.com/issue/tracker
+  license: Apache
 
-  # Some suggested licenses:
-  # - BSD (default)
-  # - MIT
-  # - GPLv2
-  # - GPLv3
-  # - Apache
-  # - CC-BY
-  license: license (GPLv2, CC-BY, etc)
+  min_ansible_version: 2.7
 
-  min_ansible_version: 2.4
-
-  # If this a Container Enabled role, provide the minimum Ansible Container version.
-  # min_ansible_container_version:
-
-  # Optionally specify the branch Galaxy will use when accessing the GitHub
-  # repo for this role. During role install, if no tags are available,
-  # Galaxy will use this branch. During import Galaxy will access files on
-  # this branch. If Travis integration is configured, only notifications for this
-  # branch will be accepted. Otherwise, in all cases, the repo's default branch
-  # (usually master) will be used.
-  #github_branch:
-
-  #
-  # Provide a list of supported platforms, and for each platform a list of versions.
-  # If you don't wish to enumerate all versions for a particular platform, use 'all'.
-  # To view available platforms and versions (or releases), visit:
-  # https://galaxy.ansible.com/api/v1/platforms/
-  #
-  # platforms:
-  # - name: Fedora
-  #   versions:
-  #   - all
-  #   - 25
-  # - name: SomePlatform
-  #   versions:
-  #   - all
-  #   - 1.0
-  #   - 7
-  #   - 99.99
-
-  galaxy_tags: []
-    # List tags for your role here, one per line. A tag is a keyword that describes
-    # and categorizes the role. Users find roles by searching for tags. Be sure to
-    # remove the '[]' above, if you add tags to this list.
-    #
-    # NOTE: A tag is limited to a single word comprised of alphanumeric characters.
-    #       Maximum 20 tags per role.
+  galaxy_tags:
+    - monitoring
+    - telemetry
 
 dependencies: []
-  # List your role dependencies here, one per line. Be sure to remove the '[]' above,
-  # if you add dependencies to this list.

--- a/roles/smartgateway/tasks/servicemonitor.yml
+++ b/roles/smartgateway/tasks/servicemonitor.yml
@@ -17,7 +17,7 @@
           - '{{ meta.namespace }}'
         endpoints:
         - port: prom-http
-          interval: 1s
+          interval: '{{ prometheus_scrape_interval }}'
           metricRelabelings:
           - action: labeldrop
             regex: pod


### PR DESCRIPTION
Allows for the Prometheus scrape interval to be set by the operator when
instantiating the service monitors for a Prometheus instance. This is required
in order to set the rate that Prometheus will scrape the Smart Gateway for
metrics.

Closes #18