### PR TITLE
Migrate repo and container image to smart-gateway-operator

### DIFF
--- a/deploy/olm-catalog/smart-gateway-operator/0.2.0/smart-gateway-operator.v0.2.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/smart-gateway-operator/0.2.0/smart-gateway-operator.v0.2.0.clusterserviceversion.yaml
@@ -32,10 +32,10 @@ metadata:
     capabilities: Basic Install
     categories: Monitoring
     certified: "false"
-    containerImage: quay.io/redhat-service-assurance/smart-gateway-operator.0.2.0:latest
+    containerImage: quay.io/redhat-service-assurance/smart-gateway-operator:latest
     createdAt: "2019-11-14T14:49:00Z"
     description: Smart Gateway Operator
-    repository: https://github.com/redhat-service-assurance/smart-gateway-operator.0.2.0
+    repository: https://github.com/redhat-service-assurance/smart-gateway-operator
     support: Red Hat (CloudOps)
   name: smart-gateway-operator.v0.2.0
   namespace: placeholder


### PR DESCRIPTION
Drop the 0.2.0 naming of the repo and container image from the CSV for the Smart
Gateway Operator