### PR TITLE
Complete path to container image

### DIFF
--- a/deploy/olm-catalog/smart-gateway-operator/0.2.0/smart-gateway-operator.v0.2.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/smart-gateway-operator/0.2.0/smart-gateway-operator.v0.2.0.clusterserviceversion.yaml
@@ -115,7 +115,7 @@ spec:
                 - /usr/local/bin/ao-logs
                 - /tmp/ansible-operator/runner
                 - stdout
-                image: quay.io/redhat-service-assurance/smart-gateway-operator.0.2.0:latest
+                image: quay.io/redhat-service-assurance/smart-gateway-operator:latest
                 imagePullPolicy: Always
                 name: ansible
                 resources: {}
@@ -136,7 +136,7 @@ spec:
                   value: smart-gateway-operator
                 - name: ANSIBLE_GATHERING
                   value: explicit
-                image: quay.io/redhat-service-assurance/smart-gateway-operator.0.2.0:latest
+                image: quay.io/redhat-service-assurance/smart-gateway-operator:latest
                 imagePullPolicy: Always
                 name: operator
                 resources: {}

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -19,14 +19,14 @@ spec:
           - /usr/local/bin/ao-logs
           - /tmp/ansible-operator/runner
           - stdout
-          image: quay.io/redhat-service-assurance/smart-gateway-operator.0.2.0:latest
+          image: quay.io/redhat-service-assurance/smart-gateway-operator:latest
           imagePullPolicy: Always
           volumeMounts:
           - mountPath: /tmp/ansible-operator/runner
             name: runner
             readOnly: true
         - name: operator
-          image: quay.io/redhat-service-assurance/smart-gateway-operator.0.2.0:latest
+          image: quay.io/redhat-service-assurance/smart-gateway-operator:latest
           imagePullPolicy: Always
           volumeMounts:
           - mountPath: /tmp/ansible-operator/runner


### PR DESCRIPTION
Previous commit I missed 4 locations that referenced the container image path.
I leveraged grep to find all of the instances and so we should be good now. I
adjusted deploy/operator.yaml manually and then ran:

  operator-sdk olm-catalog gen-csv --csv-version 0.2.0 --update-crds

Version of operator-sdk was v0.12.0. Executing that command resulted in the
container image paths being updated in the olm-catalog/